### PR TITLE
feat(io): add optional query parameter validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const exampleSchema = {
   required: ["exampleId", "exampleName"],
 };
 
-const exampleIo = new IO(exampleSchema);
+const exampleIo = new IO({ reqBodySchema: exampleSchema });
 ```
 
 Now, `ioInstance` can be included as a middleware just like any other.
@@ -101,13 +101,16 @@ router.post(
 );
 ```
 
-The final middleware function `sendResponse` will validate the response data (located at `res` object's *locals.io.data* namespace) if response JSON schema was provided as third parameter in `IO` class constructor. The second parameter is specified as `options` object which for now includes possibility to include other valid **Content-Type** headers.
+It is also possible to validate query parameters if `reqQuerySchema` is provided in `IO`s config constructor. The `options` parameter object for now includes possibility to include other valid **Content-Type** headers. The final middleware function `sendResponse` will validate the response data (located at `res` object's *locals.io.data* namespace) if response JSON schema was provided as `resBodySchema` parameter in `IO` class constructor. 
 
 ```javascript
 const exampleIo = new IO(
-  reqSchema, 
-  { contentTypes: ["text/html"] }, 
-  resSchema 
+  {
+    reqBodySchema,
+    reqQuerySchema, 
+    options: { contentTypes: ["text/html"] }, 
+    resBodySchema 
+  }
 );
 ```
 

--- a/src/io/locals.ts
+++ b/src/io/locals.ts
@@ -9,7 +9,7 @@ import _ from 'lodash';
  * Read data stored inside particular `namespace` of `obj.locals`.
  */
 export function getLocals(
-  obj: Record<string, unknown>,
+  obj: any,
   namespace: string,
   defaultValue: any = undefined,
 ): any {
@@ -23,11 +23,7 @@ export function getLocals(
  * `namespace` groups all data belonging to one middleware - for example,
  *  authentication middleware might save user id to `req.locals.auth.userId`.
  */
-export function setLocals(
-  obj: Record<string, unknown>,
-  namespace: string,
-  data: any,
-): any {
+export function setLocals(obj: any, namespace: string, data: any): any {
   if (!_.has(obj, 'locals')) {
     _.set(obj, 'locals', {});
   }

--- a/test/io/__snapshots__/io.test.ts.snap
+++ b/test/io/__snapshots__/io.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`io function processRequest throws when query is not matching schema 1`] = `"Resource does not respect the schema"`;
+
 exports[`io function sendResponse forwards the io error 1`] = `
 Object {
   "details": Object {


### PR DESCRIPTION
Yes, this is a breaking change since constructor is changed to accept different middle argument instead of just adding it to the end. However, in our code on Horst there are no cases where IO class is instantiated with >1 argument and I much prefer this order of arguments.